### PR TITLE
Add scripts to create and start chroot

### DIFF
--- a/Docs/create-chroot.md
+++ b/Docs/create-chroot.md
@@ -6,7 +6,7 @@
 
 For Arch-based Distro(Arch Linux, Manjaro): `sudo pacman -S debootstrap debian-archive-keyring xorg-xhost`
 
-For Debian-based Distro(Mobian, Ubuntu Touch??): `sudo apt install deboostrap debian-archive-keyring x11-xserver-utils`
+For Debian-based Distro(Mobian, Ubuntu Touch??): `sudo apt install debootstrap debian-archive-keyring x11-xserver-utils`
 
 
 ### Navigate to a directory and Deboostrap container

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -32,6 +32,13 @@ echo "chmod 177 /dev/shm"                  >> /root/.bashrc
 echo "export MESA_GL_VERSION_OVERRIDE=3.2" >> /root/.bashrc
 echo "export PAN_MESA_DEBUG=gl3"           >> /root/.bashrc
 echo "export PULSE_SERVER=127.0.0.1"       >> /root/.bashrc
+echo "export SDL_VIDEODRIVER=wayland"      >> /root/.bashrc
+echo "export WAYLAND_DISPLAY=wayland-1"    >> /root/.bashrc
+echo "export GDK_BACKEND=wayland"          >> /root/.bashrc
+echo "export XDG_SESSION_TYPE=wayland"     >> /root/.bashrc
+echo "export XDG_RUNTIME_DIR=/run/user/1000" >> /root/.bashrc
+echo "export DISPLAY=:1"                   >> /root/.bashrc
+echo "export XSOCKET=/tmp/.X11-unix/X1"    >> /root/.bashrc
 source /root/.bashrc
 dpkg --add-architecture arm64
 apt update

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -44,8 +44,8 @@ su user -
 cd ~/
 mkdir Downloads
 cd Downloads
-wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publish/box86_0.2.4_sid_armhf.deb
-wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publish/box64_0.1.6_sid_arm64.deb
+wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/0.2.6%2F0.1.8/box64_0.1.8_sid_generic__arm64.deb
+wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/0.2.6%2F0.1.8/box86_0.2.6_sid_generic_armhf.deb
 wget http://ftp.debian.org/debian/pool/main/libi/libindicator/libindicator7_0.5.0-4_armhf.deb
 wget http://ftp.debian.org/debian/pool/main/liba/libappindicator/libappindicator1_0.4.92-7_armhf.deb
 exit

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -4,7 +4,7 @@
 #
 mkdir /chroot
 pacman -S debootstrap debian-archive-keyring xorg-xhost
-debootstrap --arch armhf --components=main,universe bookworm /chroot/debian_gaming https://deb.debian.org/debian
+debootstrap --arch armhf --components=main,universe sid /chroot/debian_gaming https://deb.debian.org/debian
 
 #
 # Bind mount necessary directories /dev, /dev/pts, /proc, and /sys into the chroot

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -1,0 +1,63 @@
+#
+# Begin by creating a directory for the chroot (/chroot/debian_gaming), installing debootstrap,
+# and creating a bootstrapped Debian Bookworm installation
+#
+mkdir /chroot
+pacman -S debootstrap debian-archive-keyring xorg-xhost
+debootstrap --arch armhf --components=main,universe bookworm /chroot/debian_gaming https://deb.debian.org/debian
+
+#
+# Bind mount necessary directories /dev, /dev/pts, /proc, and /sys into the chroot
+#
+cd /chroot/debian_gaming
+mount -o bind /dev dev/
+mount -o bind /dev/pts dev/pts
+mount -o bind /proc proc/
+mount -o bind /sys sys/
+
+#
+# This section executes within the chroot itself
+# Begins by setting up root's .bashrc to set environment variables
+# Creates user 'user' with password 'password'
+# Installs required dependencies, box86, box64, custom libraries, and Steam
+#
+chroot /chroot/debian_gaming/ /bin/bash -x <<'EOF'
+su -
+echo "export LC_ALL=\"C\""    >> /root/.bashrc
+echo "export LANGUAGE=\"C\""  >> /root/.bashrc
+echo "export PATH=\$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/games:/usr/local/bin:/usr/local/sbin" >> /root/.bashrc
+echo "export STEAMOS=1"       >> /root/.bashrc
+echo "export STEAM_RUNTIME=1" >> /root/.bashrc
+echo "chmod 177 /dev/shm"     >> /root/.bashrc
+source /root/.bashrc
+dpkg --add-architecture arm64
+apt update
+apt install -y sudo vim make cmake git wget gnupg libx11-dev libgl-dev libvulkan-dev libtcmalloc-minimal4 libnm0 zenity chromium alsamixergui libsdl2-dev unzip libgles-dev firefox-esr:arm64 libx11-dev:arm64 libvulkan-dev:arm64 libsdl2-dev:arm64 libgl-dev:arm64 libc6-dev:arm64 libgles-dev:arm64
+adduser --home /home/user --gecos "" --disabled-password user
+echo "user:password" | chpasswd
+usermod -g users user
+adduser user sudo
+su user -
+cd ~/
+mkdir Downloads
+cd Downloads
+wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publish/box86_0.2.4_sid_armhf.deb
+wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publish/box64_0.1.6_sid_arm64.deb
+wget http://ftp.debian.org/debian/pool/main/libi/libindicator/libindicator7_0.5.0-4_armhf.deb
+wget http://ftp.debian.org/debian/pool/main/liba/libappindicator/libappindicator1_0.4.92-7_armhf.deb
+wget http://launchpadlibrarian.net/377987065/libpng12-0_1.2.54-1ubuntu1.1_armhf.deb
+exit
+apt install -y /home/user/Downloads/*.deb
+su user -
+cd ~/Downloads
+wget https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
+exit
+apt install -y /home/user/Downloads/steam_latest.deb
+EOF
+
+#
+# Copy binfmt files from chroot to host
+#
+cp /chroot/debian_gaming/etc/binfmt.d/box86.conf /etc/binfmt.d
+cp /chroot/debian_gaming/etc/binfmt.d/box64.conf /etc/binfmt.d
+systemctl restart systemd-binfmt

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -48,7 +48,6 @@ wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publi
 wget https://github.com/Raezroth/Linux-ARM-Gaming-Chroot/releases/download/publish/box64_0.1.6_sid_arm64.deb
 wget http://ftp.debian.org/debian/pool/main/libi/libindicator/libindicator7_0.5.0-4_armhf.deb
 wget http://ftp.debian.org/debian/pool/main/liba/libappindicator/libappindicator1_0.4.92-7_armhf.deb
-wget http://launchpadlibrarian.net/377987065/libpng12-0_1.2.54-1ubuntu1.1_armhf.deb
 exit
 apt install -y /home/user/Downloads/*.deb
 su user -

--- a/scripts/create_chroot.sh
+++ b/scripts/create_chroot.sh
@@ -11,7 +11,7 @@ debootstrap --arch armhf --components=main,universe bookworm /chroot/debian_gami
 #
 cd /chroot/debian_gaming
 mount -o bind /dev dev/
-mount -o bind /dev/pts dev/pts
+mount -t devpts devpts dev/pts
 mount -o bind /proc proc/
 mount -o bind /sys sys/
 
@@ -23,12 +23,15 @@ mount -o bind /sys sys/
 #
 chroot /chroot/debian_gaming/ /bin/bash -x <<'EOF'
 su -
-echo "export LC_ALL=\"C\""    >> /root/.bashrc
-echo "export LANGUAGE=\"C\""  >> /root/.bashrc
+echo "export LC_ALL=\"C\""                 >> /root/.bashrc
+echo "export LANGUAGE=\"C\""               >> /root/.bashrc
 echo "export PATH=\$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/games:/usr/local/bin:/usr/local/sbin" >> /root/.bashrc
-echo "export STEAMOS=1"       >> /root/.bashrc
-echo "export STEAM_RUNTIME=1" >> /root/.bashrc
-echo "chmod 177 /dev/shm"     >> /root/.bashrc
+echo "export STEAMOS=1"                    >> /root/.bashrc
+echo "export STEAM_RUNTIME=1"              >> /root/.bashrc
+echo "chmod 177 /dev/shm"                  >> /root/.bashrc
+echo "export MESA_GL_VERSION_OVERRIDE=3.2" >> /root/.bashrc
+echo "export PAN_MESA_DEBUG=gl3"           >> /root/.bashrc
+echo "export PULSE_SERVER=127.0.0.1"       >> /root/.bashrc
 source /root/.bashrc
 dpkg --add-architecture arm64
 apt update

--- a/scripts/start_chroot.sh
+++ b/scripts/start_chroot.sh
@@ -1,0 +1,8 @@
+cd /chroot/debian_gaming
+sudo mount -o bind /dev dev/
+sudo mount -o bind /dev/pts dev/pts
+sudo mount -o bind /proc proc/
+sudo mount -o bind /sys sys/
+xhost +local:
+sudo chmod 177 /dev/shm
+sudo chroot .

--- a/scripts/start_chroot.sh
+++ b/scripts/start_chroot.sh
@@ -1,8 +1,7 @@
 cd /chroot/debian_gaming
 sudo mount -o bind /dev dev/
-sudo mount -o bind /dev/pts dev/pts
+sudo mount -t devpts devpts dev/pts
 sudo mount -o bind /proc proc/
 sudo mount -o bind /sys sys/
 xhost +local:
-sudo chmod 177 /dev/shm
 sudo chroot .

--- a/scripts/start_chroot.sh
+++ b/scripts/start_chroot.sh
@@ -3,5 +3,7 @@ sudo mount -o bind /dev dev/
 sudo mount -t devpts devpts dev/pts
 sudo mount -o bind /proc proc/
 sudo mount -o bind /sys sys/
-xhost +local:
+sudo mount -o bind /run run/
+sudo mount -o bind /run/user/1000 run/user/1000
+sudo mount -o bind /tmp tmp/
 sudo chroot .

--- a/scripts/uninstall-chroot.sh
+++ b/scripts/uninstall-chroot.sh
@@ -2,7 +2,7 @@
 
 cd /chroot
 
-umount ./debian_gaming/*
+umount ./debian_gaming/run/user/1000 ./debian_gaming/* 
 
 rm -rf debian_gaming
 

--- a/scripts/uninstall-chroot.sh
+++ b/scripts/uninstall-chroot.sh
@@ -8,6 +8,8 @@ rm -rf debian_gaming
 
 rm -rf /etc/binfmt.d/box*
 
+systemctl restart systemd-binfmt
+
 pacman -R debootstrap debian-archive-keyring xorg-xhost
 
 

--- a/scripts/uninstall-chroot.sh
+++ b/scripts/uninstall-chroot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd /chroot
+
+umount ./debian_gaming/*
+
+rm -rf debian_gaming
+
+rm -rf /etc/binfmt.d/box*
+
+pacman -R debootstrap debian-archive-keyring xorg-xhost
+
+


### PR DESCRIPTION
Probably shouldn't merge this yet until we add some documentation, but please test these scripts.  The create_chroot.sh script must be run as root and goes through the whole setup process.  The start_chroot.sh script starts the chroot.

One addition would be to add `su user` to root's .bashrc so starting the chroot automatically lands you in the user shell not the root shell.  I also used the `sudo` group for the user rather than using visudo.