### PR TITLE
Initial Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,18 @@
 # Linux ARM Gaming Container Builder
 
-FROM arm32v7/debian:bookworm
+FROM arm64v8/debian:unstable
 
 COPY box86-binfmt.sh /box86-binfmt.sh
-RUN dpkg --add-architecture arm64
+RUN dpkg --add-architecture armhf
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y sudo wget gnupg
-RUN wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
-RUN wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | apt-key add - 
-RUN apt update && apt install box86 -y
-RUN apt install -y rss-glx:arm64 vulkan-tools:arm64
-RUN apt install -y box64
+RUN wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
+RUN wget -qO- https://ryanfortner.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg 
+RUN apt update && apt install box86-sd845 -y
+RUN wget https://ryanfortner.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
+RUN wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg 
+RUN apt update && apt install box64 -y
+RUN apt install -y rss-glx:armhf vulkan-tools:armhf
 RUN apt install -y rss-glx vulkan-tools
 RUN wget https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
 RUN apt install -y ./steam_latest.deb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y sudo wget gnupg
 RUN wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
 RUN wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | apt-key add - 
 RUN apt update && apt install box86 -y
-RUN apt install -y nano:arm64
+RUN apt install -y rss-glx:arm64 vulkan-tools:arm64
 RUN apt install -y box64
-RUN apt install -y nano
+RUN apt install -y rss-glx vulkan-tools
 RUN wget https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
 RUN apt install -y ./steam_latest.deb
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,53 @@
-# Linux ARM Gaming Container Builder
-
+######################################
+# Linux ARM Gaming Container Builder #
+######################################
 FROM arm64v8/debian:unstable
 
-COPY box86-binfmt.sh /box86-binfmt.sh
+######################################
+# Multiarch system - ARM64 and ARM32 #
+######################################
 RUN dpkg --add-architecture armhf
+
 RUN apt update
+
+##########################################
+# Install prerequisites for adding repos #
+########################################## 
 RUN DEBIAN_FRONTEND=noninteractive apt install -y sudo wget gnupg
+
+#################
+# Install box86 #
+#################
 RUN wget https://ryanfortner.github.io/box86-debs/box86.list -O /etc/apt/sources.list.d/box86.list
 RUN wget -qO- https://ryanfortner.github.io/box86-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg 
 RUN apt update && apt install box86-sd845 -y
+
+#################
+# Install box64 #
+#################
 RUN wget https://ryanfortner.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
 RUN wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg 
 RUN apt update && apt install box64 -y
-RUN apt install -y rss-glx:armhf vulkan-tools:armhf
-RUN apt install -y rss-glx vulkan-tools
+
+#################
+# Install Steam #
+#################
 RUN wget https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
 RUN apt install -y ./steam_latest.deb
 
+RUN apt install -y libxcursor1:armhf libxcursor1 libxcomposite1:armhf libxcomposite1 libxdamage1:armhf libxdamage1 libxss1:armhf libxss1 libsdl2-2.0-0:armhf libsdl2-2.0-0 libsm6:armhf libsm6 libxss1:armhf libxss1 libxtst6:armhf libxtst6 libvorbisfile3:armhf libvorbisfile3 xdg-desktop-portal-gtk libpcre3:armhf libpcre3
+
+######################
+# Add a user account #
+######################
 RUN adduser --disabled-password --gecos "" user
+
+###########################################
+# Copy box86 binfmt script into container #
+###########################################
+COPY box86-binfmt.sh /box86-binfmt.sh
+
+################################################################
+# Run box86 binfmt script when container starts and then sleep #
+################################################################
+ENTRYPOINT sh /box86-binfmt.sh && sleep infinity

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+# Linux ARM Gaming Container Builder
+
+FROM arm32v7/debian:bookworm
+
+COPY box86-binfmt.sh /box86-binfmt.sh
+RUN dpkg --add-architecture arm64
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y sudo wget gnupg
+RUN wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
+RUN wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | apt-key add - 
+RUN apt update && apt install box86 -y
+RUN apt install -y nano:arm64
+RUN apt install -y box64
+RUN apt install -y nano
+RUN wget https://repo.steampowered.com/steam/archive/stable/steam_latest.deb
+RUN apt install -y ./steam_latest.deb
+
+RUN adduser --disabled-password --gecos "" user

--- a/docker/box86-binfmt.sh
+++ b/docker/box86-binfmt.sh
@@ -1,0 +1,36 @@
+# Set up binfmt handling for box86 and box64
+# Adapted from QEMU script here: https://wiki.alpinelinux.org/wiki/How_to_make_a_cross_architecture_chroot
+
+#!/bin/bash
+
+i386_magic="\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00"
+i386_mask="\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff"
+
+x86_64_magic="\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00"
+x86_64_mask="\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff"
+
+echo "Registering box86 and box64 binaries in binfmt misc"
+
+if [ ! -d /proc/sys/fs/binfmt_misc ]; then
+    modprobe binfmt_misc || eend $? || return 1
+fi
+
+if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+    mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc >/dev/null || eend $? || return 1
+fi
+
+for arch in i386; do
+    interpreter="/usr/local/bin/box86"
+    magic=$(eval echo \$${arch}_magic)
+    mask=$(eval echo \$${arch}_mask)
+
+    echo ":box86:M::$magic:$mask:$interpreter:OCF" > /proc/sys/fs/binfmt_misc/register
+done
+
+for arch in x86_64; do
+    interpreter="/usr/local/bin/box64"
+    magic=$(eval echo \$${arch}_magic)
+    mask=$(eval echo \$${arch}_mask)
+
+    echo ":box64:M::$magic:$mask:$interpreter:OCF" > /proc/sys/fs/binfmt_misc/register
+done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,1 @@
+docker build --network host -t arm-gaming-64 .

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,2 @@
+docker container create --privileged --network host --volume /tmp/.X11-unix:/tmp/.X11-unix --env DISPLAY=$DISPLAY --name gaming arm-gaming-64
+docker start gaming


### PR DESCRIPTION
A Dockerfile creates a Docker image based on Debian Bookworm ARM32 with box86 and box64 installed, Steam, and a `user` account.  A script to set up binfmt is also provided.  Build with

`docker build -t arm-gaming .`

Run with

`docker run -it --privileged --network host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY arm-gaming bash`
